### PR TITLE
Changed spigot's dependency to 1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.18.2-R0.1-SNAPSHOT</version>
+			<version>1.16.1-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,4 +2,4 @@ name: ComfortableLife
 main: dte.comfortablelife.ComfortableLife
 version: ${project.version}
 description: Disables wandering villagers and storms, useful for testing servers. 
-api-version: 1.13
+api-version: 1.16


### PR DESCRIPTION
Because phantoms were released in 1.16, of course the plugin should ignore them in lower versions but that's WIP.